### PR TITLE
Explicitly test objects in array

### DIFF
--- a/lib/schema-inspector.js
+++ b/lib/schema-inspector.js
@@ -477,8 +477,14 @@
 					this._validate(items[i], candidate[i]);
 					this._back();
 				}
-			}
-			else {
+			} else if (schema.type === "array" && _typeIs.array(candidate)) {
+				for (i = 0; i < candidate.length; i++){
+					this._deeperArray(i);
+					this._validate(items, candidate[i])
+					this._back();
+				}
+			// Loop through an object's keys and validate them
+			} else {
 				for (var key in candidate) {
 					if (candidate.hasOwnProperty(key)){
 						this._deeperArray(key);


### PR DESCRIPTION
Fixes an issue that popped up on Ember where an array had a `__nextSuper` property. Possibly a bug in Ember that's resolve in a more recent version but a reasonable change nonetheless.
